### PR TITLE
Added Alternate path for SQLALCHEMY_DATABASE_URI( compatible with Windows)

### DIFF
--- a/Python/Flask_Blog/04-Database/flaskblog.py
+++ b/Python/Flask_Blog/04-Database/flaskblog.py
@@ -6,6 +6,9 @@ from forms import RegistrationForm, LoginForm
 app = Flask(__name__)
 app.config['SECRET_KEY'] = '5791628bb0b13ce0c676dfde280ba245'
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///site.db'
+
+# Alternate path for SQLALCHEMY_DATABASE_URI(works for Windows)
+# app.config['SQLALCHEMY_DATABASE_URI'] = os.path.join(os.path.dirname(__file__), 'site.db')
 db = SQLAlchemy(app)
 
 

--- a/Python/Flask_Blog/04-Database/flaskblog.py
+++ b/Python/Flask_Blog/04-Database/flaskblog.py
@@ -7,7 +7,7 @@ app = Flask(__name__)
 app.config['SECRET_KEY'] = '5791628bb0b13ce0c676dfde280ba245'
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///site.db'
 
-# Alternate path for SQLALCHEMY_DATABASE_URI(works for Windows)
+# Alternate path for SQLALCHEMY_DATABASE_URI( it works for Windows)
 # app.config['SQLALCHEMY_DATABASE_URI'] = os.path.join(os.path.dirname(__file__), 'site.db')
 db = SQLAlchemy(app)
 

--- a/Python/Flask_Blog/04-Database/flaskblog.py
+++ b/Python/Flask_Blog/04-Database/flaskblog.py
@@ -1,3 +1,4 @@
+# import os # this import needs to be uncommented if using the os.path.join approach for defining Database Path
 from datetime import datetime
 from flask import Flask, render_template, url_for, flash, redirect
 from flask_sqlalchemy import SQLAlchemy


### PR DESCRIPTION
Hi Corey,

I added an<b> alternate path as a comment</b> for <b>SQLALCHEMY_DATABASE_URI</b> since the <b>relative path for the database, i.e. 'sqlite:///site.db' was not working on a Windows System</b>. There <b>will not be any merge conflicts or won't affect the current application</b> since <b>the changes have been made in comments only</b>. This is just for <b>Windows user convenience</b>. Kindly accept my pull request. I have made **3 comments** as changes only in one file, i.e **flaskblog.py** at **Python/Flask_Blog/04-Database/flaskblog.py** within this repo, listed as follows:

Changes made in **Python/Flask_Blog/04-Database/flaskblog.py**:
Line 1: # import os # this import needs to be uncommented if using the os.path.join approach for defining Database Path
Line 11: # Alternate path for SQLALCHEMY_DATABASE_URI( it works for Windows)
Line 12: # app.config['SQLALCHEMY_DATABASE_URI'] = os.path.join(os.path.dirname(__file__), 'site.db')

Regards,
[Sayan Sarkar](https://github.com/Sayan3sarkar)