### PR TITLE
Update models.py

### DIFF
--- a/Python/Flask_Blog/11-Blueprints/flaskblog/models.py
+++ b/Python/Flask_Blog/11-Blueprints/flaskblog/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from itsdangerous import TimedJSONWebSignatureSerializer as Serializer
+from itsdangerous import URLSafeTimedSerializer as Serializer
 from flask import current_app
 from flaskblog import db, login_manager
 from flask_login import UserMixin
@@ -18,15 +18,15 @@ class User(db.Model, UserMixin):
     password = db.Column(db.String(60), nullable=False)
     posts = db.relationship('Post', backref='author', lazy=True)
 
-    def get_reset_token(self, expires_sec=1800):
-        s = Serializer(current_app.config['SECRET_KEY'], expires_sec)
-        return s.dumps({'user_id': self.id}).decode('utf-8')
+    def get_reset_token(self):
+        s = Serializer(current_app.config['SECRET_KEY'], 'confirmation')
+        return s.dumps({'user_id': self.id})
 
     @staticmethod
-    def verify_reset_token(token):
-        s = Serializer(current_app.config['SECRET_KEY'])
+    def verify_reset_token(token, max_age=1800):
+        s = Serializer(current_app.config['SECRET_KEY'], 'confirmation')
         try:
-            user_id = s.loads(token)['user_id']
+            user_id = s.loads(token, max_age=max_age)['user_id']
         except:
             return None
         return User.query.get(user_id)


### PR DESCRIPTION
TimedJSONWebSignatureSerializer has been deprecated from itsdangerous since version 2.1.0 recommended use: URLSafeTimedSerializer

URLSafeTimedSerializer does not have an expiration parameters, expiration paramenter. Expiration parameter can be passed to .load(token, max_age)

https://stackoverflow.com/questions/46486062/the-dumps-method-of-itsdangerous-throws-a-typeerror https://itsdangerous.palletsprojects.com/en/2.1.x/url_safe/