### PR TITLE
[Python/Flask_Blog] apply app_context to solve RunTimeError

### DIFF
--- a/Python/Flask_Blog/05-Package-Structure/flaskblog/__init__.py
+++ b/Python/Flask_Blog/05-Package-Structure/flaskblog/__init__.py
@@ -4,6 +4,7 @@ from flask_sqlalchemy import SQLAlchemy
 app = Flask(__name__)
 app.config['SECRET_KEY'] = '5791628bb0b13ce0c676dfde280ba245'
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///site.db'
-db = SQLAlchemy(app)
+with app.app_context():
+    db = SQLAlchemy(app)
 
 from flaskblog import routes

--- a/Python/Flask_Blog/06-Login-Auth/flaskblog/__init__.py
+++ b/Python/Flask_Blog/06-Login-Auth/flaskblog/__init__.py
@@ -6,10 +6,11 @@ from flask_login import LoginManager
 app = Flask(__name__)
 app.config['SECRET_KEY'] = '5791628bb0b13ce0c676dfde280ba245'
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///site.db'
-db = SQLAlchemy(app)
-bcrypt = Bcrypt(app)
-login_manager = LoginManager(app)
-login_manager.login_view = 'login'
-login_manager.login_message_category = 'info'
+with app.app_context():
+    db = SQLAlchemy(app)
+    bcrypt = Bcrypt(app)
+    login_manager = LoginManager(app)
+    login_manager.login_view = 'login'
+    login_manager.login_message_category = 'info'
 
 from flaskblog import routes

--- a/Python/Flask_Blog/07-User-Account-Profile-Pic/flaskblog/__init__.py
+++ b/Python/Flask_Blog/07-User-Account-Profile-Pic/flaskblog/__init__.py
@@ -6,10 +6,11 @@ from flask_login import LoginManager
 app = Flask(__name__)
 app.config['SECRET_KEY'] = '5791628bb0b13ce0c676dfde280ba245'
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///site.db'
-db = SQLAlchemy(app)
-bcrypt = Bcrypt(app)
-login_manager = LoginManager(app)
-login_manager.login_view = 'login'
-login_manager.login_message_category = 'info'
+with app.app_context():
+    db = SQLAlchemy(app)
+    bcrypt = Bcrypt(app)
+    login_manager = LoginManager(app)
+    login_manager.login_view = 'login'
+    login_manager.login_message_category = 'info'
 
 from flaskblog import routes

--- a/Python/Flask_Blog/08-Posts/flaskblog/__init__.py
+++ b/Python/Flask_Blog/08-Posts/flaskblog/__init__.py
@@ -6,10 +6,11 @@ from flask_login import LoginManager
 app = Flask(__name__)
 app.config['SECRET_KEY'] = '5791628bb0b13ce0c676dfde280ba245'
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///site.db'
-db = SQLAlchemy(app)
-bcrypt = Bcrypt(app)
-login_manager = LoginManager(app)
-login_manager.login_view = 'login'
-login_manager.login_message_category = 'info'
+with app.app_context():
+    db = SQLAlchemy(app)
+    bcrypt = Bcrypt(app)
+    login_manager = LoginManager(app)
+    login_manager.login_view = 'login'
+    login_manager.login_message_category = 'info'
 
 from flaskblog import routes

--- a/Python/Flask_Blog/09-Pagination/flaskblog/__init__.py
+++ b/Python/Flask_Blog/09-Pagination/flaskblog/__init__.py
@@ -6,10 +6,11 @@ from flask_login import LoginManager
 app = Flask(__name__)
 app.config['SECRET_KEY'] = '5791628bb0b13ce0c676dfde280ba245'
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///site.db'
-db = SQLAlchemy(app)
-bcrypt = Bcrypt(app)
-login_manager = LoginManager(app)
-login_manager.login_view = 'login'
-login_manager.login_message_category = 'info'
+with app.app_context():
+    db = SQLAlchemy(app)
+    bcrypt = Bcrypt(app)
+    login_manager = LoginManager(app)
+    login_manager.login_view = 'login'
+    login_manager.login_message_category = 'info'
 
 from flaskblog import routes

--- a/Python/Flask_Blog/10-Password-Reset-Email/flaskblog/__init__.py
+++ b/Python/Flask_Blog/10-Password-Reset-Email/flaskblog/__init__.py
@@ -8,16 +8,17 @@ from flask_mail import Mail
 app = Flask(__name__)
 app.config['SECRET_KEY'] = '5791628bb0b13ce0c676dfde280ba245'
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///site.db'
-db = SQLAlchemy(app)
-bcrypt = Bcrypt(app)
-login_manager = LoginManager(app)
-login_manager.login_view = 'login'
-login_manager.login_message_category = 'info'
 app.config['MAIL_SERVER'] = 'smtp.googlemail.com'
 app.config['MAIL_PORT'] = 587
 app.config['MAIL_USE_TLS'] = True
 app.config['MAIL_USERNAME'] = os.environ.get('EMAIL_USER')
 app.config['MAIL_PASSWORD'] = os.environ.get('EMAIL_PASS')
-mail = Mail(app)
+with app.app_context():
+    db = SQLAlchemy(app)
+    bcrypt = Bcrypt(app)
+    login_manager = LoginManager(app)
+    login_manager.login_view = 'login'
+    login_manager.login_message_category = 'info'
+    mail = Mail(app)
 
 from flaskblog import routes


### PR DESCRIPTION
Patch for RuntimeError in Python/Flask_Blog: 

```
RuntimeError: Working outside of application context.

This typically means that you attempted to use functionality that needed the current application. 
To solve this, set up an application context with app.app_context(). See the documentation for more information.
```

Since Flask-SQLAlchemy 3.0, all access to `db.engine` (and `db.session`) requires an active Flask application context. `db.create_all` uses `db.engine`, so it requires an app context. The solution was proposed by davidism on stackoverflow (https://stackoverflow.com/questions/73961938). More information can be found in the docs (https://flask.palletsprojects.com/en/2.3.x/appcontext/)

Changes Made:

- Added `with app.app_context():` to the relevant instances of the `__init__.py` file to provide the necessary application context.
- Verified and tested the changes to ensure they resolve the runtime error and do not introduce any new issues.

Thank you for your exceptional tutorials, as they have greatly enhanced my understanding in Python. Please review and merge this pull request at your earliest convenience. Thank you!

